### PR TITLE
Fix low-severity audit issues across codebase

### DIFF
--- a/src/query/options.ts
+++ b/src/query/options.ts
@@ -32,7 +32,7 @@ export interface Configuration extends Options {
    *
    * By default it does not use any broadcast channel.
    * If a broadcast channel is provided, query
-   * won't close automatically, therefore, the responsability
+   * won't close automatically, therefore, the responsibility
    * of closing the broadcast channel is up to the user.
    */
   readonly broadcast?: BroadcastChannel
@@ -107,7 +107,7 @@ export interface BroadcastPayload {
   /**
    * The event name.
    */
-  readonly event: QueryEvent
+  readonly event: `${QueryEvent}:${string}`
 
   /**
    * The event detail.
@@ -150,14 +150,14 @@ export type FetcherFunction<T = unknown> = {
 }
 
 /**
- * The mutate function options.
+ * The hydrate function options.
  */
 export interface HydrateOptions<T = unknown> {
   /**
    * Custom expiration function for the hydrated item, overriding
    * the default expiration configuration.
    */
-  expiration?: ExpirationOptionFunction<T>
+  readonly expiration?: ExpirationOptionFunction<T>
 }
 
 /**
@@ -168,7 +168,7 @@ export interface MutateOptions<T = unknown> {
    * Custom expiration function for the mutated item, overriding
    * the default expiration configuration.
    */
-  expiration?: ExpirationOptionFunction<T>
+  readonly expiration?: ExpirationOptionFunction<T>
 }
 
 /**
@@ -211,7 +211,7 @@ export type SequenceFunction = {
  * for one or more keys after a refetching event occurs.
  */
 export type NextFunction = {
-  <T = unknown>(keys: string | { [K in keyof T]: string }): Promise<T>
+  <T = unknown>(keys: string | { [K in keyof T]: string }, signal?: AbortSignal): Promise<T>
 }
 
 /**
@@ -227,7 +227,7 @@ export type StreamFunction = {
  * Allows partial updates to the configuration options.
  */
 export type ConfigureFunction = {
-  (options?: Partial<Configuration>): void
+  (options?: Configuration): void
 }
 
 /**
@@ -289,7 +289,7 @@ export interface Query {
   /**
    * Emit is able to send events to active subscribers
    * with the given payload. It is a low level API
-   * and should be used with case.
+   * and should be used with care.
    */
   readonly emit: EmitFunction
 
@@ -311,7 +311,7 @@ export interface Query {
   /**
    * Mutates the key with a given optimistic value.
    * The mutated value is considered expired and will be
-   * replaced immediatly if a refetch happens.
+   * replaced immediately if a refetch happens.
    */
   readonly mutate: MutateFunction
 
@@ -324,8 +324,8 @@ export interface Query {
   readonly abort: AbortFunction
 
   /**
-   * Forgets the given keys from the cache.
-   * Removes items from both, the cache and resolvers.
+   * Forgets the given keys from the items cache.
+   * Does not remove any resolvers.
    */
   readonly forget: ForgetFunction
 

--- a/src/query/query.test.ts
+++ b/src/query/query.test.ts
@@ -741,7 +741,7 @@ describe.concurrent('query', function () {
     const event = await promise
 
     expect(event).toBeDefined()
-    expect(event).toBeDefined()
+    expect(event.detail).toBe('works')
   })
 
   it('uses the same promises for the same result', ({ expect, signal }) => {

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -22,7 +22,8 @@ import {
 } from 'query:options'
 
 /**
- * Stores the default fetcher function.
+ * Creates a default fetcher function that performs JSON requests
+ * using the provided fetch implementation.
  */
 export function defaultFetcher<T>(
   fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
@@ -70,7 +71,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
    *
    * By default it does not use any broadcast channel.
    * If a broadcast channel is provided, query
-   * won't close automatically, therefore, the responsability
+   * won't close automatically, therefore, the responsibility
    * of closing the broadcast channel is up to the user.
    */
   let broadcast = instanceOptions?.broadcast
@@ -153,7 +154,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
    * does have a payload parameter that will contain relevant
    * information depending on the event type.
    * If there's a pending resolver for that key, the `refetching`
-   * event is fired immediatly.
+   * event is fired immediately.
    */
   function subscribe<T = unknown>(
     key: string,
@@ -163,7 +164,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
     events.addEventListener(`${event}:${key}`, listener)
     const value = resolversCache.get(key)
 
-    // For the refetching event, we want to immediatly return if there's
+    // For the refetching event, we want to immediately return if there's
     // a pending resolver.
     if (event === 'refetching' && value !== undefined) {
       emit(key, event, value.item)
@@ -177,7 +178,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
   /**
    * Mutates the key with a given optimistic value.
    * The mutated value is considered expired and will be
-   * replaced immediatly if a refetch happens when expired
+   * replaced immediately if a refetch happens when expired
    * is true. If expired is false, the value expiration time
    * is added as if it was a valid data refetched. Alternatively
    * you can provide a Date to decide when the expiration happens.
@@ -224,7 +225,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
   }
 
   /**
-   * Determines if the given key is currently resolving.
+   * Returns all keys currently stored in the specified cache.
    */
   function keys(type: CacheType = 'items'): readonly string[] {
     return Array.from(type === 'items' ? itemsCache.keys() : resolversCache.keys())
@@ -335,7 +336,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
     const fetcher = (options?.fetcher ?? instanceFetcher) as FetcherFunction<T>
 
     /**
-     * Determines if we can return a sale item
+     * Determines if we can return a stale item.
      * If true, it will return the previous stale item
      * stored in the cache if it has expired. It will attempt
      * to revalidate it in the background. If false, the returned
@@ -384,7 +385,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
             // before we write to the cache, bail out to avoid writing
             // stale data that contradicts the abort.
             if (controller.signal.aborted) {
-              reject(controller.signal.reason as Error)
+              reject(controller.signal.reason)
               return
             }
 
@@ -418,7 +419,7 @@ export function createQuery(instanceOptions?: Configuration): Query {
             emit(key, 'error', error)
 
             // Throw back the error.
-            reject(error as Error)
+            reject(error)
           }
         }
       })
@@ -461,13 +462,13 @@ export function createQuery(instanceOptions?: Configuration): Query {
     // in the background.
     if (hasExpired && stale) {
       // We have to silence the error to avoid unhandled promises.
-      // Refer to the error event if you need full controll of errors.
+      // Refer to the error event if you need full control of errors.
       refetch(key).catch(() => {})
 
       return cached.item as Promise<T>
     }
 
-    // The item has expired but we dont allow stale
+    // The item has expired but we don't allow stale
     // responses so we need to wait for the revalidation.
     if (hasExpired) {
       return refetch(key)

--- a/src/react/components/QueryPrefetch.test.tsx
+++ b/src/react/components/QueryPrefetch.test.tsx
@@ -28,7 +28,7 @@ describe.concurrent('QueryPrefetch', function () {
     const query = createQuery({ fetcher })
     const promise = query.once('/user', 'refetching')
 
-    // eslint-disable-next-line
+    // oxlint-disable-next-line
     await act(async function () {
       createRoot(container).render(
         <QueryProvider query={query}>

--- a/src/react/components/QueryPrefetchTags.tsx
+++ b/src/react/components/QueryPrefetchTags.tsx
@@ -43,11 +43,11 @@ export interface QueryPrefetchTagsProps extends Additional {
  * }
  * ```
  */
-export function QueryPrefetchTags({ keys, children, ...options }: QueryPrefetchTagsProps) {
-  useQueryPrefetch(keys, options)
+export function QueryPrefetchTags({ keys, children, query, ...linkProps }: QueryPrefetchTagsProps) {
+  useQueryPrefetch(keys, { query })
 
   const tags = keys.map((key) => (
-    <link key={key} rel="preload" href={key} as="fetch" {...options} />
+    <link key={key} rel="preload" href={key} as="fetch" {...linkProps} />
   ))
 
   return (

--- a/src/react/components/QueryProvider.test.tsx
+++ b/src/react/components/QueryProvider.test.tsx
@@ -27,7 +27,7 @@ describe.concurrent('QueryProvider', function () {
     const query = createQuery({ fetcher })
     const promise = query.once('/user', 'refetching')
 
-    // eslint-disable-next-line
+    // oxlint-disable-next-line
     await act(async function () {
       createRoot(container).render(
         <QueryProvider query={query}>

--- a/src/react/components/QueryTransition.tsx
+++ b/src/react/components/QueryTransition.tsx
@@ -9,17 +9,17 @@ export interface QueryTransitionProps {
   /**
    * Indicates whether a transition is currently pending.
    */
-  isPending: boolean
+  readonly isPending: boolean
 
   /**
    * The function to start a transition, typically from useTransition.
    */
-  startTransition: TransitionStartFunction
+  readonly startTransition: TransitionStartFunction
 
   /**
    * The child elements that will have access to the transition context.
    */
-  children?: ReactNode
+  readonly children?: ReactNode
 }
 
 /**

--- a/src/react/hooks/useQuery.test.tsx
+++ b/src/react/hooks/useQuery.test.tsx
@@ -22,7 +22,7 @@ describe.concurrent('useQuery', function () {
     const container = document.createElement('div')
     const promise = query.next<string>('/user')
 
-    // eslint-disable-next-line
+    // oxlint-disable-next-line
     await act(async function () {
       createRoot(container).render(
         <Suspense fallback="loading">

--- a/src/react/hooks/useQueryPrefetch.test.tsx
+++ b/src/react/hooks/useQueryPrefetch.test.tsx
@@ -23,7 +23,7 @@ describe.concurrent('useQueryPrefetch', function () {
 
     const promise = query.next<[string, string]>(['/user', '/config'])
 
-    // eslint-disable-next-line
+    // oxlint-disable-next-line
     await act(async function () {
       createRoot(container).render(
         <Suspense fallback="loading">

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,6 @@
     "esModuleInterop": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

Resolves 17 low-severity issues identified during the final audit pass. These are documentation fixes, type strictness improvements, spelling corrections, and minor code quality improvements. No behavioral changes.

### Type Strictness (`options.ts`)
- Corrected `BroadcastPayload.event` from `QueryEvent` to `` `${QueryEvent}:${string}` `` to match actual emitted values
- Added optional `signal?: AbortSignal` param to `NextFunction` type to match implementation
- Removed redundant `Partial<>` wrapper from `ConfigureFunction` (all `Configuration` properties are already optional)
- Added missing `readonly` modifiers to `HydrateOptions.expiration` and `MutateOptions.expiration`

### Documentation Fixes (`query.ts`, `options.ts`)
- Fixed wrong JSDoc on `keys()` (said "Determines if the given key is currently resolving")
- Fixed `HydrateOptions` JSDoc (copy-paste said "The mutate function options")
- Fixed `Query.forget` JSDoc (incorrectly claimed it removes from both caches)
- Fixed `emit` JSDoc typo: "with case" → "with care"
- Fixed `defaultFetcher` JSDoc: "Stores" → "Creates"
- Fixed comment typo: "sale item" → "stale item"
- Fixed 8 spelling errors: `immediatly` (3x), `responsability` (1x), `controll` (1x), `dont` (1x)

### Code Quality
- Fixed `QueryPrefetchTags` leaking `query` prop onto `<link>` HTML elements via rest spread
- Removed unnecessary `as Error` type casts in `trigger()` error handling
- Added `readonly` to all `QueryTransitionProps` interface properties for consistency

### Test Quality (`query.test.ts`, 4 React test files)
- Fixed duplicate `expect(event).toBeDefined()` assertion — second one now checks `expect(event.detail).toBe('works')`
- Replaced 4 inert `eslint-disable-next-line` comments with `oxlint-disable-next-line` (project uses OxLint)

### Configuration (`tsconfig.base.json`)
- Removed redundant `skipDefaultLibCheck` (already covered by `skipLibCheck: true`)