### PR TITLE
docs: update documentation links to docs.lambda-studio.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Lambda Query is a library created to manage asynchronous data on your code. This
 
 ## Documentation
 
-Find out about the project and discover the features at the [Documentation](https://erik.cat/blog/query-docs/)
+Find out about the project and discover the features at the [Documentation](https://docs.lambda-studio.com/query/getting-started/)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ui",
     "vanilla"
   ],
-  "homepage": "https://erik.cat/blog/query-docs",
+  "homepage": "https://docs.lambda-studio.com/query/getting-started/",
   "license": "MIT",
   "author": {
     "name": "Erik C. Forés",


### PR DESCRIPTION
## Summary

- Updates documentation URL from `erik.cat/blog/query-docs/` to `docs.lambda-studio.com/query/getting-started/`
- Changed in `README.md` (documentation link) and `package.json` (`homepage` field)